### PR TITLE
Windows compatibility and CommonJS interop change back to Babel 5 functionality

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,6 @@
-{ "presets": ["env"] }
+{
+    "presets": ["env"],
+    "plugins": [
+        "add-module-exports"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm run clean && npm run build-module && npm run build-bundle",
     "build-module": "babel src -d dist",
     "build-bundle": "rollup src/index.js --format cjs -c --output dist/bundle.js && rollup test/index.js -c -f umd --output test/bundle.js",
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "prepublish": "npm run build",
     "postversion": "git add package.json && git commit -m \"chore(package): update version\"",
     "postpublish": "gh-release"
@@ -39,6 +39,7 @@
     "babel-preset-env": "^1.2.1",
     "babel-preset-es2015-rollup": "^3.0.0",
     "gh-release": "^2.2.1",
+    "rimraf": "^2.6.1",
     "rollup": "^0.41.4",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-env": "^1.2.1",
     "babel-preset-es2015-rollup": "^3.0.0",
     "gh-release": "^2.2.1",


### PR DESCRIPTION
Hi, I have two changes.

**Windows Compatibility**
Use `rimraf` package which mirrors `rm -rf` behaviour. This is for compatibility with Windows on the 
`clean` script.

**CommonJS interop issue with exports.default**
Because you're using Babel 6, `exports default` gets transformed to `exports.default` as ES6 module. For CommonJS interoperability it is needed to now import this module with `.default` which is not desirable as evident by #116. `babel-plugin-add-module-exports` reverts to Babel 5 functionality, which does the same as above, but also adds a `module.exports` line for CommonJS.