### PR TITLE
Feat: Separate animation logic and allow overriding scrolling behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.4.0] - 2017-11-17
+
+### Added
+
+* New `handleScroll` option allows customizing scrolling behavior.
+
+### Changed
+
+* Animation logic is separated from scroll calculation logic. This allows skip
+  importing animation dependencies and reduces bundle sizes when you don't need
+  the built in animation feature.
+
 ## [1.3.0] - 2017-11-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,32 @@ Change the easing mechanism. This option takes effect when `duration` is set. In
 [bezier easing](https://www.npmjs.com/package/bezier-easing) similar to CSS
 [`cubic-bezier()`](<https://developer.mozilla.org/en-US/docs/Web/CSS/single-transition-timing-function#cubic-bezier()>).
 
+#### handleScroll(parent, {scrollLeft, scrollTop}, options)
+
+Type: `function`
+
+Take control over how the target is scrolled into view. This function is called
+for each parent node that need scrolling. `scrollLeft` and `scrollTop` are
+destination coordinates. The from coordinates you'll have to get yourself if you
+want to animate the transition using a different library.
+
+When using this option you likely don't need the built in animation feature. To
+cut down on filesize you can do the following adjustment if you are using a
+recent version of webpack or rollbar (and use ES6 imports):
+
+```diff
+-import scrollIntoViewIfNeeded from 'scroll-into-view-if-needed'
++import maybeScrollIntoView from 'scroll-into-view-if-needed/dist/calculate'
+
+-scrollIntoViewIfNeeded(node)
++maybeScrollIntoView(node, {handleScroll: (parent, {scrollLeft, scrollTop}, config) => {
++  // The following is actually the default implementation
++  // if this is all you need you can skip passing this option
++  parent.scrollLeft = scrollLeft
++  parent.scrollTop = scrollTop
++}})
+```
+
 #### offset
 
 Type: `Object`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Change the easing mechanism. This option takes effect when `duration` is set. In
 
 #### handleScroll(parent, {scrollLeft, scrollTop}, options)
 
+> Introduced in v1.4.0
+
 Type: `function`
 
 Take control over how the target is scrolled into view. This function is called

--- a/src/calculate.ts
+++ b/src/calculate.ts
@@ -1,0 +1,139 @@
+export interface Offset {
+  top?: number
+  right?: number
+  bottom?: number
+  left?: number
+}
+
+export interface ScrollCoordinates {
+  scrollLeft: number
+  scrollTop: number
+}
+export type handleScrollCallback = (
+  parent: HTMLElement,
+  coordinates: ScrollCoordinates,
+  config: Options
+) => void
+
+export interface Options {
+  // A handler that handles scrolling the view to the new coordinates
+  handleScroll?: handleScrollCallback
+  boundary?: Element
+  centerIfNeeded?: boolean
+  offset?: Offset
+}
+
+const handleScroll: handleScrollCallback = (
+  parent: HTMLElement,
+  { scrollLeft, scrollTop }
+) => {
+  parent.scrollLeft = scrollLeft
+  parent.scrollTop = scrollTop
+}
+
+export default function calculate(target: Element, options: Options) {
+  if (!target || !(target instanceof HTMLElement))
+    throw new Error('Element is required in scrollIntoViewIfNeeded')
+
+  const config = { handleScroll, ...options }
+  const defaultOffset = { top: 0, right: 0, bottom: 0, left: 0 }
+  config.offset = config.offset
+    ? { ...defaultOffset, ...config.offset }
+    : defaultOffset
+
+  function withinBounds(value, min, max, extent) {
+    if (
+      config.centerIfNeeded === false ||
+      (max <= value + extent && value <= min + extent)
+    ) {
+      return Math.min(max, Math.max(min, value))
+    } else {
+      return (min + max) / 2
+    }
+  }
+
+  const { offset } = config
+  const offsetTop = offset.top
+  const offsetLeft = offset.left
+  const offsetBottom = offset.bottom
+  const offsetRight = offset.right
+
+  function makeArea(left, top, width, height) {
+    return {
+      left: left + offsetLeft,
+      top: top + offsetTop,
+      width: width,
+      height: height,
+      right: left + offsetLeft + width + offsetRight,
+      bottom: top + offsetTop + height + offsetBottom,
+      translate: function(x, y) {
+        return makeArea(
+          x + left + offsetLeft,
+          y + top + offsetTop,
+          width,
+          height
+        )
+      },
+      relativeFromTo: function(lhs, rhs) {
+        let newLeft = left + offsetLeft,
+          newTop = top + offsetTop
+        lhs = lhs.offsetParent
+        rhs = rhs.offsetParent
+        if (lhs === rhs) {
+          return area
+        }
+        for (; lhs; lhs = lhs.offsetParent) {
+          newLeft += lhs.offsetLeft + lhs.clientLeft
+          newTop += lhs.offsetTop + lhs.clientTop
+        }
+        for (; rhs; rhs = rhs.offsetParent) {
+          newLeft -= rhs.offsetLeft + rhs.clientLeft
+          newTop -= rhs.offsetTop + rhs.clientTop
+        }
+        return makeArea(newLeft, newTop, width, height)
+      },
+    }
+  }
+
+  let parent,
+    area = makeArea(
+      target.offsetLeft,
+      target.offsetTop,
+      target.offsetWidth,
+      target.offsetHeight
+    )
+  while (
+    (parent = target.parentNode) instanceof HTMLElement &&
+    target !== config.boundary
+  ) {
+    const clientLeft = parent.offsetLeft + parent.clientLeft
+    const clientTop = parent.offsetTop + parent.clientTop
+
+    // Make area relative to parent's client area.
+    area = area
+      .relativeFromTo(target, parent)
+      .translate(-clientLeft, -clientTop)
+
+    const scrollLeft = withinBounds(
+      parent.scrollLeft,
+      area.right - parent.clientWidth,
+      area.left,
+      parent.clientWidth
+    )
+    const scrollTop = withinBounds(
+      parent.scrollTop,
+      area.bottom - parent.clientHeight,
+      area.top,
+      parent.clientHeight
+    )
+    // Pass the new coordinates to the handleScroll callback
+    config.handleScroll(parent, { scrollLeft, scrollTop }, config)
+
+    // Determine actual scroll amount by reading back scroll properties.
+    area = area.translate(
+      clientLeft - parent.scrollLeft,
+      clientTop - parent.scrollTop
+    )
+    target = parent
+  }
+}


### PR DESCRIPTION
## Changelog
### Added
 
* New `handleScroll` option allows customizing scrolling behavior.
 
### Changed
 
* Animation logic is separated from scroll calculation logic. This allows skip
  importing animation dependencies and reduces bundle sizes when you don't need
  the built in animation feature.

## Documentation

Take control over how the target is scrolled into view. This function is called
for each parent node that need scrolling. `scrollLeft` and `scrollTop` are
destination coordinates. The from coordinates you'll have to get yourself if you
want to animate the transition using a different library.
 
When using this option you likely don't need the built in animation feature. To
cut down on filesize you can do the following adjustment if you are using a
recent version of webpack or rollbar (and use ES6 imports):
 
```diff
-import scrollIntoViewIfNeeded from 'scroll-into-view-if-needed'
+import maybeScrollIntoView from 'scroll-into-view-if-needed/dist/calculate'
 
-scrollIntoViewIfNeeded(node)
+maybeScrollIntoView(node, {handleScroll: (parent, {scrollLeft, scrollTop}, config) => {
+  // The following is actually the default implementation
+  // if this is all you need you can skip passing this option
+  parent.scrollLeft = scrollLeft
+  parent.scrollTop = scrollTop
+}})
```