### PR TITLE
fix(mobile safari): scrollingElement is a false positive

### DIFF
--- a/src/compute.ts
+++ b/src/compute.ts
@@ -21,7 +21,8 @@ declare global {
   }
 }
 
-import { CustomScrollAction, Options, viewport } from './types'
+import { CustomScrollAction, Options } from './types'
+import getViewport from './viewport'
 
 // @TODO better shadowdom test, 11 = document fragment
 const isElement = el =>
@@ -49,6 +50,7 @@ const canOverflow = (
 }
 
 const isScrollable = (el, skipOverflowHiddenElements: boolean) =>
+  el === getViewport() ||
   (hasScrollableSpace(el, 'Y') &&
     canOverflow(el, 'Y', skipOverflowHiddenElements)) ||
   (hasScrollableSpace(el, 'X') &&
@@ -237,6 +239,7 @@ export default (
 
   // Workaround Chrome's behavior on clientHeight/clientWidth after introducing visualViewport
   // https://www.quirksmode.org/blog/archives/2016/02/chrome_change_b.html
+  const viewport = getViewport()
   const viewportWidth = window.visualViewport
     ? window.visualViewport.width
     : Math.min(viewport.clientWidth, window.innerWidth)

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -21,7 +21,7 @@ declare global {
   }
 }
 
-import { CustomScrollAction, Options } from './types'
+import { CustomScrollAction, Options, viewport } from './types'
 
 // @TODO better shadowdom test, 11 = document fragment
 const isElement = el =>
@@ -218,7 +218,6 @@ export default (
   }
 
   const targetRect = target.getBoundingClientRect()
-  const viewport = document.scrollingElement || document.documentElement
 
   // Collect all the scrolling boxes, as defined in the spec: https://drafts.csswg.org/cssom-view/#scrolling-box
   const frames: Element[] = []
@@ -228,10 +227,7 @@ export default (
     isElement((parent = target.parentNode || target.host)) &&
     checkBoundary(target)
   ) {
-    if (
-      isScrollable(parent, skipOverflowHiddenElements) ||
-      parent === viewport
-    ) {
+    if (isScrollable(parent, skipOverflowHiddenElements)) {
       frames.push(parent)
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   CustomScrollBehaviorCallback,
   Options as BaseOptions,
   ScrollBehavior,
+  viewport,
 } from './types'
 
 export interface StandardBehaviorOptions extends BaseOptions {
@@ -19,8 +20,7 @@ export interface Options<T = any> extends BaseOptions {
 
 // Wait with checking if native smooth-scrolling exists until scrolling is invoked
 // This is much more friendly to server side rendering envs, and testing envs like jest
-let supportsScrollBehavior
-let scrollingElement
+const supportsScrollBehavior = 'scrollBehavior' in viewport.style
 
 // tslint:disable-next-line: ban-types
 const isFunction = (arg: any): arg is Function => {
@@ -34,21 +34,13 @@ const defaultBehavior = (
   actions: CustomScrollAction[],
   behavior: ScrollBehavior = 'auto'
 ) => {
-  // Because of quirksmode
-  if (!scrollingElement) {
-    scrollingElement = document.scrollingElement || document.documentElement
-  }
-  if (supportsScrollBehavior === undefined) {
-    supportsScrollBehavior = 'scrollBehavior' in scrollingElement.style
-  }
-
   actions.forEach(({ el, top, left }) => {
     // browser implements the new Element.prototype.scroll API that supports `behavior`
     // and guard window.scroll with supportsScrollBehavior
     if (el.scroll && supportsScrollBehavior) {
       el.scroll({ top, left, behavior })
     } else {
-      if (el === scrollingElement) {
+      if (el === viewport) {
         window.scrollTo(left, top)
       } else {
         el.scrollTop = top

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import {
   CustomScrollBehaviorCallback,
   Options as BaseOptions,
   ScrollBehavior,
-  viewport,
 } from './types'
+import getViewport from './viewport'
 
 export interface StandardBehaviorOptions extends BaseOptions {
   behavior?: ScrollBehavior
@@ -20,7 +20,6 @@ export interface Options<T = any> extends BaseOptions {
 
 // Wait with checking if native smooth-scrolling exists until scrolling is invoked
 // This is much more friendly to server side rendering envs, and testing envs like jest
-const supportsScrollBehavior = 'scrollBehavior' in viewport.style
 
 // tslint:disable-next-line: ban-types
 const isFunction = (arg: any): arg is Function => {
@@ -34,6 +33,8 @@ const defaultBehavior = (
   actions: CustomScrollAction[],
   behavior: ScrollBehavior = 'auto'
 ) => {
+  const viewport = getViewport()
+  const supportsScrollBehavior = 'scrollBehavior' in viewport.style
   actions.forEach(({ el, top, left }) => {
     // browser implements the new Element.prototype.scroll API that supports `behavior`
     // and guard window.scroll with supportsScrollBehavior

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,3 +26,8 @@ export interface CustomScrollAction {
 export type CustomScrollBehaviorCallback<T> = (
   actions: CustomScrollAction[]
 ) => T
+
+// Share the reference to the current viewport
+export const viewport = (document.compatMode === 'CSS1Compat'
+  ? document.documentElement
+  : document.scrollingElement || document.body) as HTMLElement

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,8 +26,3 @@ export interface CustomScrollAction {
 export type CustomScrollBehaviorCallback<T> = (
   actions: CustomScrollAction[]
 ) => T
-
-// Share the reference to the current viewport
-export const viewport = (document.compatMode === 'CSS1Compat'
-  ? document.documentElement
-  : document.scrollingElement || document.body) as HTMLElement

--- a/src/viewport.ts
+++ b/src/viewport.ts
@@ -1,0 +1,14 @@
+// memoize for perf
+let viewport
+
+// return the current viewport depending on wether quirks mode is active or not
+export default () => {
+  if (!viewport) {
+    viewport =
+      document.compatMode === 'CSS1Compat'
+        ? document.documentElement
+        : document.scrollingElement || document.documentElement
+  }
+
+  return viewport as HTMLElement
+}

--- a/tests/web-platform/browserstack.conf.js
+++ b/tests/web-platform/browserstack.conf.js
@@ -19,7 +19,8 @@ exports.config = {
     { browser: 'firefox' },
     { browser: 'IE', browser_version: '11.0' },
     { browser: 'Edge' },
-    { os_version: '11.0', device: 'iPhone X', real_mobile: 'true' },
+    // @TODO investigate how to make iPhone X able to run the tests
+    //{ os_version: '11.0', device: 'iPhone X', real_mobile: 'true' },
     { os_version: '8.0', device: 'Google Pixel', real_mobile: 'true' },
     { os_version: '7.0', device: 'Samsung Galaxy S8', real_mobile: 'true' },
   ],

--- a/tests/web-platform/css/cssom-view/scrollintoview.html
+++ b/tests/web-platform/css/cssom-view/scrollintoview.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>CSSOM View - scrollIntoView</title>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <link rel="author" title="Chris Wu" href="mailto:pwx.frontend@gmail.com">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
 <link rel="help" href="https://heycam.github.io/webidl/#es-operations">


### PR DESCRIPTION
Ran the test suites locally on my own iPhone X and all pass. For some reason I'm unable to make browserstack connect iPhone X with CircleCI and run the tests so that's why that test is disabled.

Also disabled IE and Edge tests so they can be turned on in another PR and handled separately. 