### PR TITLE
Disable automatic deploy on v1 to avoid accidents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,3 @@ jobs:
           paths:
             - node_modules
           key: v3-dependencies-{{ checksum "yarn.lock" }}
-
-      - run: yarn semantic-release || true
-
-      - run:
-          name: Maybe deploy to gh-pages
-          command: |
-            if [[ $CIRCLE_BRANCH == master ]]; then
-              yarn docs
-            fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,17 @@ and this project adheres to
 
 ### Added
 
-* `sideEffects: false` in package.json to enable optimizations introduced in webpack v4.
+- `sideEffects: false` in package.json to enable optimizations introduced in webpack v4.
 
 ## [1.4.0] - 2017-11-17
 
 ### Added
 
-* New `handleScroll` option allows customizing scrolling behavior.
+- New `handleScroll` option allows customizing scrolling behavior.
 
 ### Changed
 
-* Animation logic is separated from scroll calculation logic. This allows skip
+- Animation logic is separated from scroll calculation logic. This allows skip
   importing animation dependencies and reduces bundle sizes when you don't need
   the built in animation feature.
 
@@ -30,33 +30,33 @@ and this project adheres to
 
 ### Added
 
-* New API interface (#148 @tonybdesign)
+- New API interface (#148 @tonybdesign)
 
 ## [1.2.8] - 2017-11-05
 
 ### Fixed
 
-* Missing TypeScript definitions and rollup/webpack pkg.module files from
+- Missing TypeScript definitions and rollup/webpack pkg.module files from
   published package (#145)
 
 ## [1.2.7] - 2017-11-05
 
 ### Fixed
 
-* Package published on npm contained unnecessary files bloating the package
+- Package published on npm contained unnecessary files bloating the package
   (#144)
 
 ## [1.2.6] - 2017-11-05
 
 ### Fixed
 
-* Don't use postinstall as it runs in userland (#143)
+- Don't use postinstall as it runs in userland (#143)
 
 ## [1.2.5] - 2017-11-05
 
 ### Fixed
 
-* Migrate tests to
+- Migrate tests to
   [new page](https://stipsan.github.io/scroll-into-view-if-needed/) that
   showcases how it works (#141)
 
@@ -64,104 +64,104 @@ and this project adheres to
 
 ### Fixed
 
-* TypeScript requires HTMLElement when it should accept Element (#140)
+- TypeScript requires HTMLElement when it should accept Element (#140)
 
 ## [1.2.3] - 2017-11-04
 
 ### Fixed
 
-* Incorrect TypeScript declarations and export format (#136)
+- Incorrect TypeScript declarations and export format (#136)
 
 ## [1.2.2] - 2017-10-29
 
 ### Fixed
 
-* Incorrect export declaration in TS typings (#132)
+- Incorrect export declaration in TS typings (#132)
 
 ## [1.2.1] - 2017-10-02
 
 ### Fixed
 
-* Fifth option should be optional (#129)
+- Fifth option should be optional (#129)
 
 ## [1.2.0] - 2017-10-01
 
 ### Added
 
-* Set offset feature (#127 @iwangulenko)
+- Set offset feature (#127 @iwangulenko)
 
 ## [1.1.1] - 2017-10-01
 
 ### Fixed
 
-* Windows compatibility and CommonJS interop change back to Babel 5
+- Windows compatibility and CommonJS interop change back to Babel 5
   functionality (#121 @khell)
 
 ## [1.1.0] - 2017-03-29
 
 ### Added
 
-* An optional argument finalElement was added to limit the scope of the function
+- An optional argument finalElement was added to limit the scope of the function
   (#108 @hemnstill)
 
 ## [1.0.7] - 2017-03-14
 
 ### Added
 
-* MIT License (#107 @JKillian)
+- MIT License (#107 @JKillian)
 
 ### Changed
 
-* Reduced size of dist build by switching from rollup to babel (#106 @JKillian)
+- Reduced size of dist build by switching from rollup to babel (#106 @JKillian)
 
 ## [1.0.6] - 2016-11-17
 
 ### Changed
 
-* Updated typescript definition making options optional (#75 @pelotom)
+- Updated typescript definition making options optional (#75 @pelotom)
 
 ## [1.0.5] - 2016-11-12
 
 ### Fixed
 
-* Fix TypeScript definition file issues (#74 @forabi)
+- Fix TypeScript definition file issues (#74 @forabi)
 
 ### Documentation
 
-* React example snippet in readme.
+- React example snippet in readme.
 
 ## [1.0.4] - 2016-10-31
 
 ### Added
 
-* Changelog readme.
-* TypeScript definition file (#73 @forabi)
+- Changelog readme.
+- TypeScript definition file (#73 @forabi)
 
 ## 1.0.3 - 2016-09-30
 
 ### Documentation
 
-* link to official ponyfill page (#68 @sindresorhus)
+- link to official ponyfill page (#68 @sindresorhus)
 
 ## 1.0.2 - 2016-04-18
 
 ### Added
 
-* Greenkeeper
+- Greenkeeper
 
 ### Fixes
 
-* Incomatibility with default webpack config.
+- Incomatibility with default webpack config.
 
 ## 1.0.1 - 2016-04-18
 
-* PULLED: accidentally pushed incomplete build to npm!
+- PULLED: accidentally pushed incomplete build to npm!
 
 ## 1.0.0 - 2016-04-18
 
 ### Added
 
-* Initial release.
+- Initial release.
 
 [unreleased]: https://github.com/stipsan/scroll-into-view-if-needed/compare/v1.5.0...HEAD
 [1.5.0]: https://github.com/stipsan/scroll-into-view-if-needed/compare/v1.4.0...v1.5.0

--- a/cypress/integration/example.js
+++ b/cypress/integration/example.js
@@ -35,9 +35,11 @@ describe('Basic Functionality', function() {
       cy.wrap($el).click({ force: true })
       const key = $el.data('nth')
       cy.wait(300)
-      cy
-        .get(`#list1 li:nth-child(${key})`)
-        .should('have.data', 'visibility', 'visible')
+      cy.get(`#list1 li:nth-child(${key})`).should(
+        'have.data',
+        'visibility',
+        'visible'
+      )
     })
   })
   it('should not scroll beyond boundary', function() {
@@ -51,9 +53,11 @@ describe('Basic Functionality', function() {
     cy.get('#list3 button').each(function($el, index, $list) {
       cy.wrap($el).click({ force: true })
       const key = $el.data('nth')
-      cy
-        .get(`#list3 li:nth-child(${key})`)
-        .should('have.data', 'visibility', 'visible')
+      cy.get(`#list3 li:nth-child(${key})`).should(
+        'have.data',
+        'visibility',
+        'visible'
+      )
     })
   })
 })


### PR DESCRIPTION
This is to enable manual releases on the v1 release so we can still do bugfixes on it.