### PR TITLE
Update renovate hourly limit to avoid browserstack queue limit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     ":automergeDigest",
     ":automergeMinor",
     ":automergeRequireAllStatusChecks",
-    ":prHourlyLimit4",
+    ":prHourlyLimit1",
     ":semanticCommits",
     ":pinDigestsDisabled",
     ":maintainLockFilesWeekly"


### PR DESCRIPTION
Which can cause false negatives as the ci times out while waiting for browserstack tests to start