### PR TITLE
fix: target attached logic for shadow dom element

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,19 +64,19 @@ function scrollIntoView<T>(
 function scrollIntoView(target: Element, options?: Options | boolean): void
 function scrollIntoView<T>(target: Element, options?: Options<T> | boolean) {
   // Browsers treats targets that aren't in the dom as a no-op and so should we
-  const targetIsDetached = !target.ownerDocument!.documentElement!.contains(
-    target
-  )
+  const isTargetAttached =
+    target.isConnected ||
+    target.ownerDocument!.documentElement!.contains(target)
 
   if (
     isOptionsObject<CustomBehaviorOptions<T>>(options) &&
     typeof options.behavior === 'function'
   ) {
-    return options.behavior(targetIsDetached ? [] : compute(target, options))
+    return options.behavior(isTargetAttached ? compute(target, options) : [])
   }
 
   // Don't do anything if using a standard behavior on an element that is not in the document
-  if (targetIsDetached) {
+  if (!isTargetAttached) {
     return
   }
 


### PR DESCRIPTION
fixes #860

The problem was, that `.documentElement.contains(shadowRootChild)` always returns false for shadow dom elements even if they're attached.

Usage of `.isConnected` method fixes this problem with a fallback  to the previous logic for IE (as IE doesn't support `.isConnected` method)